### PR TITLE
Add trade PnL visualizer and fix scoring bug

### DIFF
--- a/insider_data.py
+++ b/insider_data.py
@@ -87,9 +87,10 @@ class InsiderData:
     def get_score(self, ticker):
         if self.scores is None:
             raise ValueError('Please run compute_score beforehand.')
-        row = self.scores[self.scores['Ticker']] == ticker
-        score = float(row['Score'].values[0])
-        return score
+        row = self.scores[self.scores['Ticker'] == ticker]
+        if row.empty:
+            return 0.0
+        return float(row['Score'].values[0])
     
     def get_df(self):
         if self.clean_data is None:

--- a/visualizer.py
+++ b/visualizer.py
@@ -1,0 +1,24 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def plot_trade_returns(trades):
+    """Plot cumulative profit/loss for each ticker over time."""
+    if not trades:
+        print("No trades to plot")
+        return
+
+    df = pd.DataFrame(trades)
+    df["exit_date"] = pd.to_datetime(df["exit_date"])
+    df = df.sort_values("exit_date")
+
+    pivot = df.pivot_table(index="exit_date", columns="ticker", values="pnl", aggfunc="sum").fillna(0)
+    cumulative = pivot.cumsum()
+
+    ax = cumulative.plot(marker="o", figsize=(10, 6))
+    ax.set_title("Trade Profit/Loss Over Time")
+    ax.set_xlabel("Exit Date")
+    ax.set_ylabel("Cumulative PnL")
+    ax.grid(True, linestyle="--", alpha=0.6)
+    plt.tight_layout()
+    plt.show()


### PR DESCRIPTION
## Summary
- add custom TradeListAnalyzer to record each trade
- plot cumulative profit/loss by ticker with `plot_trade_returns`
- expose the plot from the backtest engine
- fix ticker lookup bug in `InsiderData.get_score`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68814d5e25ac83298c5cb92b03c0911a